### PR TITLE
Enable random results and refine button by default

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -55,3 +55,6 @@ Changes
 -------
 
 * Changed READMEs from .md to .rst and improved formatting consistency
+
+* The "Toggle Random Results" and "Refine" buttons are now enabled by default
+  to let the user test database images as queries.

--- a/smqtk_iqr/web/search_app/modules/iqr/static/js/smqtk.iqr_refine_view.js
+++ b/smqtk_iqr/web/search_app/modules/iqr/static/js/smqtk.iqr_refine_view.js
@@ -201,7 +201,7 @@ IqrRefineView.prototype.update_refine_pane = function () {
             else {
                 // disable buttons + hide bottom button container
                 // noinspection JSValidateTypes
-                self.button_container_refine_top.children().prop("disabled", true);
+                self.button_container_refine_top.children().prop("disabled", false);
                 self.button_container_refine_bot.hide();
             }
         }
@@ -253,6 +253,7 @@ IqrRefineView.prototype.iqr_refine = function() {
     // helper methods for display stuff
     function disable_buttons() {
         // noinspection JSValidateTypes
+        self.button_container_refine_top.children().not(self.button_toggle_random).prop("disabled", false);
         self.button_container_refine_top.children().prop("disabled", true);
         self.button_container_refine_bot.children().prop("disabled", true);
     }


### PR DESCRIPTION
This change allows users to test out random database images as queries. The main use case is when repopulated descriptors are being used, which means there isn't a way for a user to upload a query image and have it compute its descriptor.