### PR TITLE
Improve error message when ports are in use

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -64,3 +64,5 @@ Changes
 
 * The "Toggle Random Results" and "Refine" buttons are now enabled by default
   to let the user test database images as queries.
+
+* Added debugging information to server exception when ports are in use.

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -66,3 +66,5 @@ Changes
   to let the user test database images as queries.
 
 * Added debugging information to server exception when ports are in use.
+
+* Use xdoctest in testing instead of regular doctest

--- a/poetry.lock
+++ b/poetry.lock
@@ -1573,6 +1573,29 @@ files = [
 watchdog = ["watchdog"]
 
 [[package]]
+name = "xdoctest"
+version = "1.1.6"
+description = "A rewrite of the builtin doctest module"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "xdoctest-1.1.6-py3-none-any.whl", hash = "sha256:a6f673df8c82b8fe0adc536f14c523464f25c6d2b733ed78888b8f8d6c46012e"},
+    {file = "xdoctest-1.1.6.tar.gz", hash = "sha256:00ec7bde36addbedf5d1db0db57b6b669a7a4b29ad2d16480950556644f02109"},
+]
+
+[package.extras]
+all = ["IPython (>=7.10.0)", "IPython (>=7.23.1)", "Pygments (>=2.0.0)", "Pygments (>=2.4.1)", "attrs (>=19.2.0)", "colorama (>=0.4.1)", "debugpy (>=1.0.0)", "debugpy (>=1.0.0)", "debugpy (>=1.0.0)", "debugpy (>=1.3.0)", "debugpy (>=1.6.0)", "ipykernel (>=5.2.0)", "ipykernel (>=6.0.0)", "ipykernel (>=6.11.0)", "ipython-genutils (>=0.2.0)", "jedi (>=0.16)", "jinja2 (>=3.0.0)", "jupyter-client (>=6.1.5)", "jupyter-client (>=7.0.0)", "jupyter-core (>=4.7.0)", "nbconvert (>=6.0.0)", "nbconvert (>=6.1.0)", "pyflakes (>=2.2.0)", "pytest (>=4.6.0)", "pytest (>=4.6.0)", "pytest (>=6.2.5)", "pytest-cov (>=3.0.0)", "tomli (>=0.2.0)", "typing (>=3.7.4)"]
+all-strict = ["IPython (==7.10.0)", "IPython (==7.23.1)", "Pygments (==2.0.0)", "Pygments (==2.4.1)", "attrs (==19.2.0)", "colorama (==0.4.1)", "debugpy (==1.0.0)", "debugpy (==1.0.0)", "debugpy (==1.0.0)", "debugpy (==1.3.0)", "debugpy (==1.6.0)", "ipykernel (==5.2.0)", "ipykernel (==6.0.0)", "ipykernel (==6.11.0)", "ipython-genutils (==0.2.0)", "jedi (==0.16)", "jinja2 (==3.0.0)", "jupyter-client (==6.1.5)", "jupyter-client (==7.0.0)", "jupyter-core (==4.7.0)", "nbconvert (==6.0.0)", "nbconvert (==6.1.0)", "pyflakes (==2.2.0)", "pytest (==4.6.0)", "pytest (==4.6.0)", "pytest (==6.2.5)", "pytest-cov (==3.0.0)", "tomli (==0.2.0)", "typing (==3.7.4)"]
+colors = ["Pygments", "Pygments", "colorama"]
+jupyter = ["IPython", "IPython", "attrs", "debugpy", "debugpy", "debugpy", "debugpy", "debugpy", "ipykernel", "ipykernel", "ipykernel", "ipython-genutils", "jedi", "jinja2", "jupyter-client", "jupyter-client", "jupyter-core", "nbconvert", "nbconvert"]
+optional = ["IPython (>=7.10.0)", "IPython (>=7.23.1)", "Pygments (>=2.0.0)", "Pygments (>=2.4.1)", "attrs (>=19.2.0)", "colorama (>=0.4.1)", "debugpy (>=1.0.0)", "debugpy (>=1.0.0)", "debugpy (>=1.0.0)", "debugpy (>=1.3.0)", "debugpy (>=1.6.0)", "ipykernel (>=5.2.0)", "ipykernel (>=6.0.0)", "ipykernel (>=6.11.0)", "ipython-genutils (>=0.2.0)", "jedi (>=0.16)", "jinja2 (>=3.0.0)", "jupyter-client (>=6.1.5)", "jupyter-client (>=7.0.0)", "jupyter-core (>=4.7.0)", "nbconvert (>=6.0.0)", "nbconvert (>=6.1.0)", "pyflakes (>=2.2.0)", "tomli (>=0.2.0)"]
+optional-strict = ["IPython (==7.10.0)", "IPython (==7.23.1)", "Pygments (==2.0.0)", "Pygments (==2.4.1)", "attrs (==19.2.0)", "colorama (==0.4.1)", "debugpy (==1.0.0)", "debugpy (==1.0.0)", "debugpy (==1.0.0)", "debugpy (==1.3.0)", "debugpy (==1.6.0)", "ipykernel (==5.2.0)", "ipykernel (==6.0.0)", "ipykernel (==6.11.0)", "ipython-genutils (==0.2.0)", "jedi (==0.16)", "jinja2 (==3.0.0)", "jupyter-client (==6.1.5)", "jupyter-client (==7.0.0)", "jupyter-core (==4.7.0)", "nbconvert (==6.0.0)", "nbconvert (==6.1.0)", "pyflakes (==2.2.0)", "tomli (==0.2.0)"]
+tests = ["pytest (>=4.6.0)", "pytest (>=4.6.0)", "pytest (>=6.2.5)", "pytest-cov (>=3.0.0)", "typing (>=3.7.4)"]
+tests-binary = ["cmake", "cmake", "ninja", "ninja", "pybind11", "pybind11", "scikit-build", "scikit-build"]
+tests-binary-strict = ["cmake (==3.21.2)", "cmake (==3.25.0)", "ninja (==1.10.2)", "ninja (==1.11.1)", "pybind11 (==2.10.3)", "pybind11 (==2.7.1)", "scikit-build (==0.11.1)", "scikit-build (==0.16.1)"]
+tests-strict = ["pytest (==4.6.0)", "pytest (==4.6.0)", "pytest (==6.2.5)", "pytest-cov (==3.0.0)", "typing (==3.7.4)"]
+
+[[package]]
 name = "zipp"
 version = "3.5.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -1590,4 +1613,4 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "92dd1bb9a5beb4c18c626841766a3464f9cdb5f93e511b78f9271505996aea6c"
+content-hash = "520829b6d5c0c06b268ebf1d6387c6cb0146eeafc56447c8a288032a96a5aae4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ sphinx-prompt = "^1.4.0"
 livereload = "^2.6.3"
 # Testing
 coverage = "^5.5"
+xdoctest = "^1.1.5"
 pytest = "^6.2.5"
 pytest-cov = "^3.0.0"
 # Development
@@ -71,7 +72,7 @@ smqtk-nn-index-tool = "smqtk_iqr.utils.nn_index_tool:cli_group"
 [tool.pytest.ini_options]
 addopts = [
     "-lv",                      # Show local in trace-backs.
-    "--doctest-modules",        # Increased verbosity.
+    "--xdoctest-modules",       # Increased verbosity.
     "--tb=long",                # Trace-back print mode.
     "--cov=./smqtk_iqr",        # Cover our package specifically
     "--cov=./tests",            # Cover tests

--- a/smqtk_iqr/web/__init__.py
+++ b/smqtk_iqr/web/__init__.py
@@ -129,8 +129,7 @@ class SmqtkWebApp (flask.Flask, Plugfigurable):
                     f'``sudo lsof -t -i tcp:{port}``'
                 )
             note = '. '.join(note_parts)
-            add_exception_note(ex, note)
-            raise
+            raise add_exception_note(ex, note)
 
 
 def add_exception_note(


### PR DESCRIPTION
I was attempting to start the SMQTK server, but got an error saying the address was in use. I did not immediately know how to debug this, nor was I sure exactly which port was the problem.

This patch adds a note to the exception indicating what the keyword arguments passed to the `run` method are. Also, if it sees that it is an address already in use error, it will provide the user some extra information about how to debug which processes are using that port.

This vendors in a utility from [kwutil.util_exception](https://gitlab.kitware.com/computer-vision/kwutil/-/blob/main/kwutil/util_exception.py?ref_type=heads), which augments extensions by modifying the message in pre-3.11 python, and in python >= 3.11, it uses the exception note mechanism.