### PR TITLE
Fix flask werkzeug with new versions

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -31,10 +31,6 @@ Miscellaneous
 
 * Updated minimum version to Python 3.7
 
-* Handle versions of werkzeug > 2.0.0 up to at least 3.0.4
-
-* Handle versions of flask > 2.0.1 up to at least 3.0.3
-
 Fixes
 -----
 
@@ -54,6 +50,12 @@ Dependency Versions
   since recent ipython update appropriately addresses the dependency.
 
 * Updated readthedocs config
+
+* Updated pillow requirement to allow for more recent versions.
+
+* Handle versions of werkzeug > 2.0.0 up to at least 3.0.4
+
+* Handle versions of flask > 2.0.1 up to at least 3.0.3
 
 Changes
 -------

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -31,6 +31,10 @@ Miscellaneous
 
 * Updated minimum version to Python 3.7
 
+* Handle versions of werkzeug > 2.0.0 up to at least 3.0.4
+
+* Handle versions of flask > 2.0.1 up to at least 3.0.3
+
 Fixes
 -----
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1590,4 +1590,4 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "0cafb53108b992e1f18b4f77e6aa07a41227f22dac2123ac7d4046a73669f48c"
+content-hash = "92dd1bb9a5beb4c18c626841766a3464f9cdb5f93e511b78f9271505996aea6c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Flask-Cors = "^3.0.10"
 imageio = "^2.9.0"
 Flask-BasicAuth = "^0.2.0"
 smqtk-classifier = ">=0.18.0"
-Pillow = "^8.3.2"
+Pillow = ">=8.3.2"
 
 [tool.poetry.dev-dependencies]
 # CI

--- a/smqtk_iqr/web/search_app/__init__.py
+++ b/smqtk_iqr/web/search_app/__init__.py
@@ -8,12 +8,12 @@ import os
 import os.path
 import threading
 import logging
-from typing import Callable, Dict, Any, Optional
+import sys
+from typing import Callable, Dict, Any, Optional, Union
 
 import flask
 from flask_cors import cross_origin
 from werkzeug.exceptions import NotFound
-from werkzeug.wsgi import peek_path_info, pop_path_info
 
 from smqtk_core.dict import merge_dict
 
@@ -286,3 +286,130 @@ class IqrSearchDispatcher (SmqtkWebApp):
 
 
 APPLICATION_CLASS = IqrSearchDispatcher
+
+
+def peek_path_info(
+    environ, charset: str = "utf-8", errors: str = "replace"
+) -> Optional[str]:
+    """
+    Vendored from werkzeug 2.0.0, should try to remove in the future.
+
+    note: type of environ is WSGIEnvironment
+
+    Returns the next segment on the `PATH_INFO` or `None` if there
+    is none.  Works like :func:`pop_path_info` without modifying the
+    environment:
+
+    >>> env = {'SCRIPT_NAME': '/foo', 'PATH_INFO': '/a/b'}
+    >>> peek_path_info(env)
+    'a'
+    >>> peek_path_info(env)
+    'a'
+
+    If the `charset` is set to `None` bytes are returned.
+
+    .. deprecated:: 2.2
+        Will be removed in Werkzeug 2.3.
+
+    .. versionadded:: 0.5
+
+    .. versionchanged:: 0.9
+       The path is now decoded and a charset and encoding
+       parameter can be provided.
+
+    :param environ: the WSGI environment that is checked.
+    """
+    segments = environ.get("PATH_INFO", "").lstrip("/").split("/", 1)
+    if segments:
+        return _to_str(  # type: ignore
+            segments[0].encode("latin1"), charset, errors, allow_none_charset=True
+        )
+    return None
+
+
+def pop_path_info(
+    environ, charset: str = "utf-8", errors: str = "replace"
+) -> Optional[str]:
+    """
+    Vendored from werkzeug 2.0.0, should try to remove in the future.
+
+    note: type of environ is WSGIEnvironment
+
+    Removes and returns the next segment of `PATH_INFO`, pushing it onto
+    `SCRIPT_NAME`.  Returns `None` if there is nothing left on `PATH_INFO`.
+
+    If the `charset` is set to `None` bytes are returned.
+
+    If there are empty segments (``'/foo//bar``) these are ignored but
+    properly pushed to the `SCRIPT_NAME`:
+
+    >>> env = {'SCRIPT_NAME': '/foo', 'PATH_INFO': '/a/b'}
+    >>> pop_path_info(env)
+    'a'
+    >>> env['SCRIPT_NAME']
+    '/foo/a'
+    >>> pop_path_info(env)
+    'b'
+    >>> env['SCRIPT_NAME']
+    '/foo/a/b'
+
+    .. deprecated:: 2.2
+        Will be removed in Werkzeug 2.3.
+
+    .. versionadded:: 0.5
+
+    .. versionchanged:: 0.9
+       The path is now decoded and a charset and encoding
+       parameter can be provided.
+
+    :param environ: the WSGI environment that is modified.
+    :param charset: The ``encoding`` parameter passed to
+        :func:`bytes.decode`.
+    :param errors: The ``errors`` paramater passed to
+        :func:`bytes.decode`.
+    """
+    path = environ.get("PATH_INFO")
+    if not path:
+        return None
+
+    script_name = environ.get("SCRIPT_NAME", "")
+
+    # shift multiple leading slashes over
+    old_path = path
+    path = path.lstrip("/")
+    if path != old_path:
+        script_name += "/" * (len(old_path) - len(path))
+
+    if "/" not in path:
+        environ["PATH_INFO"] = ""
+        environ["SCRIPT_NAME"] = script_name + path
+        rv = path.encode("latin1")
+    else:
+        segment, path = path.split("/", 1)
+        environ["PATH_INFO"] = f"/{path}"
+        environ["SCRIPT_NAME"] = script_name + segment
+        rv = segment.encode("latin1")
+
+    return _to_str(rv, charset, errors, allow_none_charset=True)  # type: ignore
+
+
+_default_encoding = sys.getdefaultencoding()
+
+
+def _to_str(
+    x: Optional[Any],
+    charset: Optional[str] = _default_encoding,
+    errors: str = "strict",
+    allow_none_charset: bool = False,
+) -> Optional[Union[str, bytes]]:
+    if x is None or isinstance(x, str):
+        return x
+
+    if not isinstance(x, (bytes, bytearray)):
+        return str(x)
+
+    if charset is None:
+        if allow_none_charset:
+            return x
+
+    return x.decode(charset, errors)  # type: ignore

--- a/smqtk_iqr/web/search_app/__init__.py
+++ b/smqtk_iqr/web/search_app/__init__.py
@@ -289,7 +289,7 @@ APPLICATION_CLASS = IqrSearchDispatcher
 
 
 def peek_path_info(
-    environ, charset: str = "utf-8", errors: str = "replace"
+    environ: dict, charset: str = "utf-8", errors: str = "replace"
 ) -> Optional[str]:
     """
     Vendored from werkzeug 2.0.0, should try to remove in the future.
@@ -328,7 +328,7 @@ def peek_path_info(
 
 
 def pop_path_info(
-    environ, charset: str = "utf-8", errors: str = "replace"
+    environ: dict, charset: str = "utf-8", errors: str = "replace"
 ) -> Optional[str]:
     """
     Vendored from werkzeug 2.0.0, should try to remove in the future.


### PR DESCRIPTION
This patch fixes the web interface such that it works with newer versions of flask and werkzeug.

This involves:

* using a try except around the old way of handling session_cookie_name (this patch was done with Paul Beasly, which I think also involved some black formatting)

* Vendoring in old versions of functions that were deprecated and removed from werkzeug: peek_path_info, pop_path_info, and _to_str. 

It might be nice to put the vendored functions in a separate module: e.g. "smqtk_iqr/_compat.py" or  "smqtk_iqr/_monkey.py" to reduce clutter in `__init__.py`.