### PR TITLE
[DRAFT] Add Tutorial #1 (dummy descriptors on kwcoco demo data)

### DIFF
--- a/docs/environment/installing_mongodb.rst
+++ b/docs/environment/installing_mongodb.rst
@@ -1,0 +1,50 @@
+Installing MongoDB
+------------------
+
+This gives a minimal set of instructions for how to install and setup MongoDB
+Community Edition on Ubuntu machines.
+
+
+For a more detailed tutorial see:
+
+    https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-ubuntu/
+
+
+On Ubuntu 22.04 run:
+
+.. code:: bash
+
+    sudo apt-get install gnupg curl
+
+    curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc | \
+      sudo gpg -o /usr/share/keyrings/mongodb-server-7.0.gpg \
+      --dearmor
+
+    # Print OS Info
+    lsb_release -a
+
+    # Point to the correct package repo depending on the OS
+    if lsb_release -a 2> /dev/null | grep "Ubuntu 20.04" ; then
+        echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/7.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+    elif lsb_release -a 2> /dev/null | grep "Ubuntu 22.04" ; then
+        echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+    else
+        echo "Unsupported Ubuntu Version"
+    fi
+
+    sudo apt-get update
+    sudo apt-get install -y mongodb-org
+
+    # Start the mongo service
+    sudo systemctl start mongod
+
+    # Check the status of the service
+    systemctl status mongod --no-pager
+
+    # Test the service works by attempting to interact with it
+    mongosh --eval "db.getMongo()"
+    # Should have message:
+    # connecting to: mongodb://127.0.0.1:27017
+
+    # View available databases:
+    mongosh --eval "show dbs"

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -6,16 +6,8 @@ Updates / New Features
 
 Tutorial to Perform IQR on Prepopulated Descriptor Set
 
-* Added directory `docs/tutorialsfile` that has code to perform IQR on a
-  prepopulated descriptor set. Documentation found in `demo_notes.sh`.
-
-* Updated `pyproject.toml` to accept more recent versions of pillow package.
-
-* Updated `smqtk_iqr/utils/mongo_sessions.py` for flask version 2.0.1 by
-  extracting `cookie_session_name` from config file.
-
-* Modified `mqtk_iqr/web/search_app/modules/iqr/static/js/smqtk.iqr_refine_view.js`
-  to enable "Toggle Random Results" and "Refine" buttons at beginning of session.
+* Added directory `docs/tutorials` that has code to perform IQR on a
+  prepopulated descriptor set.
 
 Auto-negative Selection
 

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -4,6 +4,19 @@ Pending Release Notes
 Updates / New Features
 ----------------------
 
+Tutorial to Perform IQR on Prepopulated Descriptor Set
+
+* Added directory `docs/tutorialsfile` that has code to perform IQR on a
+  prepopulated descriptor set. Documentation found in `demo_notes.sh`.
+
+* Updated `pyproject.toml` to accept more recent versions of pillow package.
+
+* Updated `smqtk_iqr/utils/mongo_sessions.py` for flask version 2.0.1 by
+  extracting `cookie_session_name` from config file.
+
+* Modified `mqtk_iqr/web/search_app/modules/iqr/static/js/smqtk.iqr_refine_view.js`
+  to enable "Toggle Random Results" and "Refine" buttons at beginning of session.
+
 Auto-negative Selection
 
 * Added auto-negative selection in IqrSession for negative adjudications

--- a/docs/tutorials/.gitignore
+++ b/docs/tutorials/.gitignore
@@ -1,0 +1,2 @@
+models
+workdir

--- a/docs/tutorials/README.rst
+++ b/docs/tutorials/README.rst
@@ -1,0 +1,6 @@
+SMQTK-IQR Tutorials
+-------------------
+
+This folder contains a set of SMQTK tutorials. See:
+
+* tutorial_001_kwcoco_dummy_descriptors/README.rst

--- a/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/README.rst
+++ b/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/README.rst
@@ -1,0 +1,11 @@
+Tutorial 1 - Demo KWCoco with Dummy Descriptors
+-----------------------------------------------
+
+This tutorial demonstrates the how to run the IQR pipeline on an arbitrary
+kwcoco file, but with hand-crafted overly simplified descriptors. This means
+that this tutorial does not involve any significant computation, but it still
+demonstrates the end-to-end pipeline.
+
+
+The script ``./run_tutorial_001.sh`` is a well-documented bash script that you
+should step through manually to understand the individual steps of the process.

--- a/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/ingest_precomputed_descriptors.py
+++ b/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/ingest_precomputed_descriptors.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+# Generates models for IQR applcation with prepopulated descriptors.
+# Generates image data set, descriptor set, and nearest neighbors index.
+# Implements the 'PrePopulatedDescriptorGenerator' class
+
+# Standard libraries
+import logging
+import os.path as osp
+import os
+import json
+import numpy as np
+import sys
+
+import ubelt as ub
+import scriptconfig as scfg
+
+# SMQTK specific packages
+from smqtk_iqr.utils import cli
+from smqtk_dataprovider import DataSet
+from smqtk_dataprovider.impls.data_element.file import DataFileElement
+from smqtk_descriptors.descriptor_element_factory import DescriptorElementFactory
+from smqtk_descriptors import DescriptorSet
+from smqtk_indexing import NearestNeighborsIndex
+from smqtk_core.configuration import (
+    from_config_dict,
+)
+
+
+# ---------------------------------------------------------------
+class IngestPrecomputedDescriptorsConfig(scfg.DataConfig):
+    """
+    Define the configuration class using the scriptconfig package for CLI args
+    """
+
+    verbose = scfg.Value(
+        False, isflag=True, short_alias=["v"], help="Output additional debug logging."
+    )
+    config = scfg.Value(
+        None,
+        required=True,
+        short_alias=["c"],
+        help=ub.paragraph(
+            """
+            Path to the JSON configuration files. The first file
+            provided should be the configuration file for the
+            ``IqrSearchDispatcher`` web-application and the second
+            should be the configuration file for the ``IqrService`` web-
+            application.
+            """
+        ),
+        nargs=2,
+    )
+    manifest_fpath = scfg.Value(
+        None,
+        short_alias=["m"],
+        help=ub.paragraph(
+            """
+            Path to the JSON descriptor metadata files. Contains pairs of
+            image and descriptor file paths.
+            """
+        ),
+    )
+    tab = scfg.Value(
+        None,
+        required=True,
+        short_alias=["t"],
+        help=ub.paragraph(
+            """
+            The configuration "tab" of the ``IqrSearchDispatcher``
+            configuration to use. This informs what dataset to add the
+            input data files to.
+            """
+        ),
+    )
+
+    debug_nn_index = scfg.Value(False, isflag=1, help='if True, test to see if a NN index can be created and works')
+
+
+# ---------------------------------------------------------------
+def remove_cache_files(ui_config, iqr_config) -> None:
+    """
+    Remove any existing cache files in defined in config file paths
+    """
+    data_cache = ui_config["iqr_tabs"]["GEOWATCH_DEMO"]["data_set"][
+        "smqtk_dataprovider.impls.data_set.memory.DataMemorySet"
+    ]["cache_element"]["smqtk_dataprovider.impls.data_element.file.DataFileElement"][
+        "filepath"
+    ]
+    # Deleting the file
+    if os.path.exists(data_cache):
+        os.remove(data_cache)
+        print(f"\nFile {data_cache} deleted successfully")
+    else:
+        print(f"File {data_cache} does not exist - will be generated")
+
+    # Remove any existing cache files in descriptor set config file path
+    descriptor_cache = iqr_config["iqr_service"]["plugins"]["descriptor_set"][
+        "smqtk_descriptors.impls.descriptor_set.memory.MemoryDescriptorSet"
+    ]["cache_element"]["smqtk_dataprovider.impls.data_element.file.DataFileElement"][
+        "filepath"
+    ]
+
+    # Deleting the file if it exists
+    if descriptor_cache and os.path.exists(descriptor_cache):
+        os.remove(descriptor_cache)
+        print(f"File '{descriptor_cache}' deleted successfully")
+    else:
+        print(f"File '{descriptor_cache}' does not exist - will be generated")
+
+
+# ---------------------------------------------------------------
+def generate_sets(manifest_path, data_set, descriptor_set, descriptor_elem_factory):
+    """
+    Loads metadata from the JSON file and builds a data by adding each image.
+    From the data set, each image UUID is used to generate the associated
+    desciptor and build the descriptor set.
+    """
+    # Load JSON data from the file
+    with open(manifest_path, "r") as json_file:
+        data = json.load(json_file)
+
+    # Access the list of image-descriptor pairs
+    image_descriptor_pairs = data["Image_Descriptor_Pairs"]
+
+    # Iterate over each pair to build the data set and descriptor set
+    for pair in image_descriptor_pairs:
+
+        # Extract image path and descriptor path
+        image_path = pair["image_path"]
+        image_path = osp.expanduser(image_path)
+
+        desc_path = pair["desc_path"]
+        desc_path = osp.expanduser(desc_path)
+
+        if osp.isfile(image_path) and osp.isfile(desc_path):
+            data_fe = DataFileElement(image_path, readonly=True)
+            data_set.add_data(data_fe)
+
+            # Load the associated descriptor json vector
+            with open(desc_path, "rb") as f:
+                json_vec = json.load(f)
+            vector = np.array(json_vec)
+
+            # print(f"vector shape {vector.shape}")
+
+            # Generate descriptor element with image uuid and known vector
+            descriptor = descriptor_elem_factory.new_descriptor(data_fe.uuid())
+            descriptor.set_vector(vector)
+
+            descriptor_set.add_descriptor(descriptor)
+
+        else:
+            print("\n Image or descriptor file paths not found")
+
+    return data_set, descriptor_set
+
+
+# ---------------------------------------------------------------
+# A simple function to get the nth descriptor from the descriptor set
+# Displays the UUID and vector of the descriptor
+def get_nth_descriptor(descriptor_set, n):
+    desc_iter = descriptor_set.descriptors()
+    for i in range(n):
+        desc = next(desc_iter)
+    print(f"\nDescriptor {n} info, uuid: {desc.uuid()}, vector: {desc.vector()}")
+    return desc
+
+
+# ---------------------------------------------------------------
+def main() -> None:
+    # Instantiate the configuration class and gather the arguments
+    import rich
+    from rich.markup import escape
+    args = IngestPrecomputedDescriptorsConfig.cli(special_options=False, strict=True)
+    rich.print('config = ' + escape(ub.urepr(args, nl=1)))
+
+    # --------------------------------------------------------------
+    # Set up config values:
+    ui_config_filepath, iqr_config_filepath = args.config
+    llevel = logging.DEBUG if args.verbose else logging.INFO
+    manifest_path = args.manifest_fpath
+    tab = args.tab
+
+    # Not using `cli.utility_main_helper`` due to deviating from single-
+    # config-with-default usage.
+    cli.initialize_logging(logging.getLogger("smqtk_iqr"), llevel)
+    cli.initialize_logging(logging.getLogger("__main__"), llevel)
+    log = logging.getLogger(__name__)
+
+    log.info("Loading UI config: '{}'".format(ui_config_filepath))
+    ui_config, ui_config_loaded = cli.load_config(ui_config_filepath)
+    log.info("Loading IQR config: '{}'".format(iqr_config_filepath))
+    iqr_config, iqr_config_loaded = cli.load_config(iqr_config_filepath)
+    if not (ui_config_loaded and iqr_config_loaded):
+        raise RuntimeError("One or both configuration files failed to load.")
+
+    # Ensure the given "tab" exists in UI configuration.
+    if tab is None:
+        log.error("No configuration tab provided to drive model generation.")
+        sys.exit(1)
+    if tab not in ui_config["iqr_tabs"]:
+        log.error(
+            "Invalid tab provided: '{}'. Available tags: {}".format(
+                tab, list(ui_config["iqr_tabs"])
+            )
+        )
+        sys.exit(1)
+
+    # ----------------------------------------------------------------
+    # Gather Configurations
+    log.info("Extracting plugin configurations")
+
+    ui_tab_config = ui_config["iqr_tabs"][tab]
+    iqr_plugins_config = iqr_config["iqr_service"]["plugins"]
+
+    # Configure DataSet implementation and parameters
+    data_set_config = ui_tab_config["data_set"]
+
+    # Configure DescriptorElementFactory instance, which defines what
+    # implementation of DescriptorElement to use for storing generated
+    # descriptor vectors below.
+    descriptor_elem_factory_config = iqr_plugins_config["descriptor_factory"]
+
+    # Configure the DescriptorSet instance into which the descriptor elements
+    # are added.
+    descriptor_set_config = iqr_plugins_config["descriptor_set"]
+
+    # Configure NearestNeighborIndex algorithm implementation, parameters and
+    # persistent model component locations (if implementation has any).
+    nn_index_config = iqr_plugins_config["neighbor_index"]
+
+    # --------------------------------------------------------------
+    # Remove any existing cache files in data set config file path
+    remove_cache_files(ui_config, iqr_config)
+
+    # ---------------------------------------------------------------
+    # Initialize data/algorithms
+    #
+    # Constructing appropriate data structures and algorithms, needed for the
+    # IQR demo application, in preparation for model training.
+    log.info("Instantiating plugins")
+
+    # Create instance of the class DataSet from the configuration
+    data_set: DataSet = from_config_dict(data_set_config, DataSet.get_impls())
+    descriptor_elem_factory = DescriptorElementFactory.from_config(
+        descriptor_elem_factory_config
+    )
+
+    # Create instance of the class DescriptorSet from the configuration
+    descriptor_set: DescriptorSet = from_config_dict(
+        descriptor_set_config, DescriptorSet.get_impls()
+    )
+
+    # Create instance of the class NearestNeighborsIndex from the configuration
+    nn_index: NearestNeighborsIndex = from_config_dict(
+        nn_index_config, NearestNeighborsIndex.get_impls()
+    )
+
+    # Generate data set and descriptor set from the JSON manifest file
+    data_set, descriptor_set = generate_sets(
+        manifest_path, data_set, descriptor_set, descriptor_elem_factory
+    )
+
+    print(f"\nData set for IQR model with{data_set.count()} elements created")
+    print(f"Descriptor set for IQR model with {descriptor_set.count()} elements created\n")
+
+    # Debuggint/Test - test the nearest neighbors index operation works
+    if args.debug_nn_index:
+        log.info("Building nearest neighbors index {}".format(nn_index))
+        nn_index.build_index(descriptor_set)
+
+        # Debugging/Test - test nnindex with a descriptor
+        test_query_desc = get_nth_descriptor(descriptor_set, 4)
+        print(f'Testing query with: {test_query_desc}')
+        nearest_descriptors, nearest_distances = nn_index.nn(test_query_desc, 3)
+        print(f'nearest_descriptors = {ub.urepr(nearest_descriptors, nl=1)}')
+        print(f'nearest_distances = {ub.urepr(nearest_distances, nl=1)}')
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/prepare_contrived_descriptors.py
+++ b/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/prepare_contrived_descriptors.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Script to generate and chip kwcoco geowatch images and
+create associated 'dummy' descriptors.
+Descriptors contain some information about active annotations
+Stores results in a manifest.json file that has image/desciptor pairs
+with associated file paths.
+"""
+
+import scriptconfig as scfg
+import ubelt as ub
+
+
+class PrepareContrivedDescriptorsConfig(scfg.DataConfig):
+    """
+    Creates chips and contrived descriptors for images in a kwcoco dataset.
+    """
+    # Define the file paths to store generated data
+    coco_fpath = scfg.Value(None, help='input kwcoco file to create chips / descriptors for')
+    out_chips_dpath = scfg.Value('./chipped_images', help='Path to output the chips and their descriptors')
+    out_mainfest_fpath = scfg.Value('manifest.json', help='Path that references all output data')
+
+    @classmethod
+    def main(cls, cmdline=1, **kwargs):
+        """
+        Example:
+            >>> # xdoctest: +SKIP
+            >>> from chip_images_demo import *  # NOQA
+            >>> cmdline = 0
+            >>> kwargs = dict()
+            >>> cls = ChipImagesDemoCLI
+            >>> cls.main(cmdline=cmdline, **kwargs)
+        """
+        import rich
+        from rich.markup import escape
+        config = cls.cli(cmdline=cmdline, data=kwargs, strict=True, special_options=False)
+        rich.print('config = ' + escape(ub.urepr(config, nl=1)))
+
+        import numpy as np
+        import os
+        import json
+        import kwcoco
+        import kwarray
+        import kwimage
+
+        # Create the directory to store chipped images if it does not exist
+        out_mainfest_fpath = ub.Path(config.out_mainfest_fpath)
+        out_images_dpath = ub.Path(config.out_chips_dpath)
+        out_images_dpath.ensuredir()
+
+        # Define the dimensions of the window slider for image chips
+        window = (256, 256)
+
+        # Read the kwcoco dataset
+        dset = kwcoco.CocoDataset.coerce(config.coco_fpath)
+
+        # Initialize list to store image/descriptor pairs for each chipped image
+        rows = []
+
+        # Outer loop for each image in dataset
+        for ii in ub.ProgIter(range(dset.n_images), desc='chip images', verbose=3):
+
+            # Select image for slicing/chipping
+            image_id = dset.images()[ii]
+
+            # Generate a coco_image class object from the data set using the image id
+            coco_image = dset.coco_image(image_id)
+
+            # input_image_path = coco_image.primary_image_filepath()
+            # Debugging - display current image using matplotlib
+            # plt.imshow(plt.imread(input_image_path))
+            # plt.show()
+
+            # This method converts the image to a  <class 'numpy.ndarray'>
+            # The default image is 600x600 pixels with three channels, rgb
+            input_image = coco_image.imdelay("r|g|b").finalize()
+
+            # First 2 elements of image are dimensions, don't need channel info
+            shape = input_image.shape[0:2]
+
+            # Capture location (boxes), ids and names for annotations in image
+            # These are extracted from the coco_image object
+            annotations = coco_image.annots()
+            annot_boxes = kwimage.Boxes(annotations.lookup("bbox"), "xywh")
+            annot_cat_ids = np.array(annotations.lookup("category_id"))
+            annot_cat_names = dset.categories(annot_cat_ids).lookup("name")
+            print(f"Annotation ids: {annot_cat_ids} and names: {annot_cat_names}", "\n")
+
+            # Set the slider args base upon image shape and window size.
+            slider = kwarray.SlidingWindow(shape, window, allow_overshoot=True)
+            # print("\n slider params: ", slider, '\n')
+
+            # TODO: this needs to have a consistent ordering if the descriptors
+            # are used with other toy datasets
+
+            # Define the number of descriptor dimensions from number of categories
+            categories = dset.object_categories()
+            descriptor_dims = len(categories) * 2
+
+            # Chipping/slicing loop using ub.ProgIter and slider args.
+            for index in ub.ProgIter(slider, desc="sliding a window", verbose=3):
+
+                # Slice out the relevant part of the image using the slider function
+                # The index performs the slicer operation on the
+                # first two dimensions of image
+                part_image = input_image[index]
+
+                # Debugging - view each window of the image
+                # plt.imshow(part_image)
+                # plt.show()
+
+                # Get a box corresponding to the slice to use 'box' methods
+                # Box captures an area of the original image
+                # defined by positionts (x1, y1, x2, y2)
+                box = kwimage.Box.from_slice(index)
+
+                # Capture intersection area of annotation boxes with current window
+                # divided by the union of these areas using ious() method
+                annot_overlaps = annot_boxes.ious(box.boxes)[:, 0]
+
+                # Capture annotation category ids that overlap with current window
+                overlapping_cat_ids = annot_cat_ids[annot_overlaps > 0]
+                # print("Annotations that overlap: ", annot_overlaps, overlapping_cat_ids, '\n')
+
+                # Look up name of annotation category ids
+                # Extract cateory ids -> name -> index and convert to numpy array
+                overlapping_cat_names = dset.categories(overlapping_cat_ids).lookup("name")
+                overlapping_cat_idxs = np.array(
+                    [categories.node_to_idx[name] for name in overlapping_cat_names], dtype=int
+                )
+
+                # Generate descriptor with random values
+                part_descriptor = np.random.rand(descriptor_dims)
+
+                # Modify descriptor values to 100 where the category index is present
+                part_descriptor[overlapping_cat_idxs] = 100
+
+                # Converts from (x1,y1), (x2, y2) dimensions to xywh
+                x, y, w, h = box.to_xywh().data
+                # print("output of box.to_xywh: ", box, "(", x, y, w, h, ")", '\n')
+
+                # Generate file paths
+                suffix = f"img_{image_id:05d}-xywh={x:04d}_{y:04d}_{w:03d}_{h:03d}.png"
+                slice_path = out_images_dpath / suffix
+                slice_desc_path = slice_path.augment(stemsuffix="_desc", ext=".json")
+
+                # Save image chip/slice to the path defined above
+                kwimage.imwrite(slice_path, part_image)
+
+                # Convert the NumPy array to a Python list
+                part_descriptor_list = part_descriptor.tolist()
+
+                # Save the list to the JSON file
+                with open(slice_desc_path, "w") as json_file:
+                    json.dump(part_descriptor_list, json_file)
+
+                # Append to outer loop list
+                row = {
+                    "image_path": os.fspath(slice_path),
+                    "desc_path": os.fspath(slice_desc_path),
+                }
+                rows.append(row)
+
+        tables = {"Image_Descriptor_Pairs": rows}
+        print(f'Write manifest to: {out_mainfest_fpath}')
+        out_mainfest_fpath.write_text(json.dumps(tables, indent="    "))
+
+
+__cli__ = PrepareContrivedDescriptorsConfig
+
+if __name__ == '__main__':
+    """
+
+    CommandLine:
+        python ~/code/smqtk-repos/SMQTK-IQR/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/chip_images_demo.py
+        python -m chip_images_demo
+    """
+    __cli__.main()

--- a/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/runApp.IqrRestService.json
+++ b/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/runApp.IqrRestService.json
@@ -1,0 +1,148 @@
+{
+  "flask_app": {
+      "BASIC_AUTH_PASSWORD": "demo",
+      "BASIC_AUTH_USERNAME": "demo",
+      "SECRET_KEY": "MySuperUltraSecret",
+      "debug_server": true
+  },
+  "server": {
+      "host": "127.0.0.1",
+      "port": 5001
+  },
+  "iqr_service": {
+    "plugin_notes": {
+        "classification_factory": "Selection of the backend in which classifications are stored. The in-memory version is recommended because normal caching mechanisms will not account for the variety of classifiers that can potentially be created via this utility.",
+        "classifier_config": "The configuration to use for training and using classifiers for the /classifier endpoint. When configuring a classifier for use, don't fill out model persistence values as many classifiers may be created and thrown away during this service's operation.",
+        "descriptor_factory": "What descriptor element factory to use when asked to compute a descriptor on data.",
+        "descriptor_generator": "Descriptor generation algorithm to use when requested to describe data.",
+        "descriptor_set": "This is the index from which given positive and negative example descriptors are retrieved from. Not used for nearest neighbor querying. This index must contain all descriptors that could possibly be used as positive/negative examples and updated accordingly.",
+        "neighbor_index": "This is the neighbor index to pull initial near-positive descriptors from.",
+        "relevancy_index_config": "The relevancy index config provided should not have persistent storage configured as it will be used in such a way that instances are created, built and destroyed often."
+    },
+      "plugins": {
+          "classification_factory": {
+              "smqtk_classifier.impls.classification_element.memory.MemoryClassificationElement": {},
+              "type": "smqtk_classifier.impls.classification_element.memory.MemoryClassificationElement"
+          },
+          "classifier_config": {
+            "smqtk_classifier.impls.classify_descriptor_supervised.sklearn_logistic_regression.SkLearnLogisticRegression": {
+            },
+            "type": "smqtk_classifier.impls.classify_descriptor_supervised.sklearn_logistic_regression.SkLearnLogisticRegression"
+           },
+          "descriptor_factory": {
+              "smqtk_descriptors.impls.descriptor_element.memory.DescriptorMemoryElement": {},
+              "type": "smqtk_descriptors.impls.descriptor_element.memory.DescriptorMemoryElement"
+          },
+          "descriptor_generator": {
+              "smqtk_descriptors.impls.descriptor_generator.prepopulated.PrePopulatedDescriptorGenerator": {
+                },
+              "type": "smqtk_descriptors.impls.descriptor_generator.prepopulated.PrePopulatedDescriptorGenerator"
+            },
+          "descriptor_set": {
+              "smqtk_descriptors.impls.descriptor_set.memory.MemoryDescriptorSet": {
+                  "cache_element": {
+                      "smqtk_dataprovider.impls.data_element.file.DataFileElement": {
+                          "explicit_mimetype": null,
+                          "filepath": "workdir/descriptor_set.pickle",
+                          "readonly": false
+                      },
+                      "type": "smqtk_dataprovider.impls.data_element.file.DataFileElement"
+                  },
+                  "pickle_protocol": -1
+              },
+              "type": "smqtk_descriptors.impls.descriptor_set.memory.MemoryDescriptorSet"
+          },
+          "neighbor_index": {
+            "smqtk_indexing.impls.nn_index.faiss.FaissNearestNeighborsIndex": {
+                "descriptor_set": {
+                    "smqtk_descriptors.impls.descriptor_set.memory.MemoryDescriptorSet": {
+                      "cache_element": {
+                          "smqtk_dataprovider.impls.data_element.file.DataFileElement": {
+                              "explicit_mimetype": null,
+                              "filepath": "workdir/descriptor_set.pickle",
+                              "readonly": false
+                          },
+                          "type": "smqtk_dataprovider.impls.data_element.file.DataFileElement"
+                      },
+                      "pickle_protocol": -1
+                  },
+                  "type": "smqtk_descriptors.impls.descriptor_set.memory.MemoryDescriptorSet"
+                },
+                "factory_string": "IDMap,Flat",
+                "gpu_id": 0,
+                "idx2uid_kvs": {
+                    "smqtk_dataprovider.impls.key_value_store.memory.MemoryKeyValueStore": {
+                      "cache_element": {
+                          "smqtk_dataprovider.impls.data_element.file.DataFileElement": {
+                              "explicit_mimetype": null,
+                              "filepath": "workdir/idx2uid.mem_kvstore.pickle",
+                              "readonly": false
+                          },
+                          "type": "smqtk_dataprovider.impls.data_element.file.DataFileElement"
+                      }
+                  },
+                  "type": "smqtk_dataprovider.impls.key_value_store.memory.MemoryKeyValueStore"
+                },
+                "uid2idx_kvs": {
+                    "smqtk_dataprovider.impls.key_value_store.memory.MemoryKeyValueStore": {
+                      "cache_element": {
+                          "smqtk_dataprovider.impls.data_element.file.DataFileElement": {
+                              "explicit_mimetype": null,
+                              "filepath": "workdir/uid2idx.mem_kvstore.pickle",
+                              "readonly": false
+                          },
+                          "type": "smqtk_dataprovider.impls.data_element.file.DataFileElement"
+                      }
+                  },
+                  "type": "smqtk_dataprovider.impls.key_value_store.memory.MemoryKeyValueStore"
+                },
+                "index_element": {
+                    "smqtk_dataprovider.impls.data_element.file.DataFileElement": {
+                        "filepath": "models/faiss_index",
+                        "readonly": false
+                    },
+                    "type": "smqtk_dataprovider.impls.data_element.file.DataFileElement"
+                },
+                "index_param_element": {
+                    "smqtk_dataprovider.impls.data_element.file.DataFileElement": {
+                        "filepath": "models/faiss_index_params.json",
+                        "readonly": false
+                    },
+                    "type": "smqtk_dataprovider.impls.data_element.file.DataFileElement"
+                },
+                "ivf_nprobe": 64,
+                "metric_type": "l2",
+                "random_seed": 0,
+                "read_only": false,
+                "use_gpu": false
+            },
+            "type": "smqtk_indexing.impls.nn_index.faiss.FaissNearestNeighborsIndex"
+        },
+        "rank_relevancy_with_feedback": {
+            "smqtk_relevancy.impls.rank_relevancy.margin_sampling.RankRelevancyWithMarginSampledFeedback": {
+                "rank_relevancy": {
+                    "smqtk_relevancy.impls.rank_relevancy.wrap_classifier.RankRelevancyWithSupervisedClassifier": {
+                        "classifier_inst": {
+                            "smqtk_classifier.impls.classify_descriptor_supervised.sklearn_logistic_regression.SkLearnLogisticRegression": {
+                            },
+                            "type": "smqtk_classifier.impls.classify_descriptor_supervised.sklearn_logistic_regression.SkLearnLogisticRegression"
+                        }
+                    },
+                    "type": "smqtk_relevancy.impls.rank_relevancy.wrap_classifier.RankRelevancyWithSupervisedClassifier"
+                },
+                "n": 10,
+                "center": 0.5
+            },
+            "type": "smqtk_relevancy.impls.rank_relevancy.margin_sampling.RankRelevancyWithMarginSampledFeedback"
+        }
+      },
+      "session_control": {
+          "positive_seed_neighbors": 500,
+          "session_expiration": {
+              "check_interval_seconds": 30,
+              "enabled": true,
+              "session_timeout": 3600
+          }
+      }
+  }
+}

--- a/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/runApp.IqrSearchApp.json
+++ b/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/runApp.IqrSearchApp.json
@@ -1,0 +1,36 @@
+{
+    "flask_app": {
+        "BASIC_AUTH_PASSWORD": "demo",
+        "BASIC_AUTH_USERNAME": "demo",
+        "SECRET_KEY": "MySuperUltraSecret",
+        "debug": true
+    },
+    "iqr_tabs": {
+        "GEOWATCH_DEMO": {
+            "data_set": {
+                "smqtk_dataprovider.impls.data_set.memory.DataMemorySet": {
+                    "cache_element": {
+                        "smqtk_dataprovider.impls.data_element.file.DataFileElement": {
+                            "explicit_mimetype": null,
+                            "filepath": "workdir/data.memorySet.cache",
+                            "readonly": false
+                        },
+                        "type": "smqtk_dataprovider.impls.data_element.file.DataFileElement"
+                    },
+                    "pickle_protocol": -1
+                },
+                "type": "smqtk_dataprovider.impls.data_set.memory.DataMemorySet"
+            },
+            "iqr_service_url": "localhost:5001",
+            "working_directory": "workdir"
+        }
+    },
+    "mongo": {
+        "database": "smqtk",
+        "server": "127.0.0.1:27017"
+    },
+    "server": {
+        "host": "127.0.0.1",
+        "port": 5000
+    }
+}

--- a/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/run_tutorial_001.sh
+++ b/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/run_tutorial_001.sh
@@ -15,9 +15,12 @@ and the corresponding descriptor files. The manifest file is created by the
 ``prepare_contrived_descriptors.py`` script that generates image chips from
 kwcoco images and builds dummy descriptor files.
 
-Also need the faiss library to be installed
-pip install faiss-cpu==1.8.0
-pip install "psycopg2-binary>=2.9.5,<3.0.0"
+This tutorial has additional Python requirements:
+
+    pip install faiss-cpu==1.8.0
+    pip install "psycopg2-binary>=2.9.5,<3.0.0"
+    pip install scriptconfig ubelt rich kwcoco
+
 
 To install MongoDB see: ../../environment/installing_mongodb.rst
 

--- a/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/run_tutorial_001.sh
+++ b/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors/run_tutorial_001.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+__doc__='
+-----------------------------------------
+IQR demo with PrePopulated Descriptor Set
+-----------------------------------------
+
+The following guide provides steps to run the IQR demo with a prepopulated
+descriptor set. The demo was written and run with Python version 3.11.2.
+
+The ``ingest_precomputed_descriptors.py`` script is used to generate the descriptor set
+without calling the methods in one of the descriptor generator
+modules. Using the PrePopulatedDescriptorGenerator class, the descriptor set
+is generated from a manifest file that contains the paths to the image files
+and the corresponding descriptor files. The manifest file is created by the
+``prepare_contrived_descriptors.py`` script that generates image chips from
+kwcoco images and builds dummy descriptor files.
+
+Also need the faiss library to be installed
+pip install faiss-cpu==1.8.0
+pip install "psycopg2-binary>=2.9.5,<3.0.0"
+
+To install MongoDB see: ../../environment/installing_mongodb.rst
+
+This script also assumes that tmux is installed.
+
+This script should be run from inside the tutorial directory. E.g. on the
+developers machine this looks like:
+
+.. code:: bash
+
+    cd ~/code/smqtk-repos/SMQTK-IQR/docs/tutorials/tutorial_001_kwcoco_dummy_descriptors
+'
+
+# ---------------------------------------------------------------------------
+# Steps to run the IQR demo with a prepopulated descriptor set
+# ---------------------------------------------------------------------------
+
+
+# Choose a working directory where we can write data
+WORKING_DIRECTORY=./workdir
+
+
+### Setup Environment Variables
+# The location of all important paths should be knowable a-priori to running
+# this script and potentially before the data is even generated.
+KWCOCO_FPATH=$WORKING_DIRECTORY/kwcoco_bundle/data.kwcoco.json
+CHIPPED_IMAGES_DPATH=$WORKING_DIRECTORY/processed/chips
+MANIFEST_FPATH=$WORKING_DIRECTORY/processed/manifest.json
+
+echo "
+KWCOCO_FPATH         = $KWCOCO_FPATH
+CHIPPED_IMAGES_DPATH = $CHIPPED_IMAGES_DPATH
+MANIFEST_FPATH       = $MANIFEST_FPATH
+"
+
+# (Optional) Remove previous directories and contents for a clean model build
+# rm -rf "$WORKING_DIRECTORY"
+mkdir -p "$WORKING_DIRECTORY"
+
+echo "
+------
+Step 1
+------
+Generate the demo kwcoco data
+"
+
+# Generate toy datasets using the "kwcoco toydata" tool
+kwcoco toydata vidshapes2-frames10-amazon --dst "$KWCOCO_FPATH"
+
+
+echo "
+------
+Step 2
+------
+Convert the kwcoco file into a directory of chipped images with descriptors.
+"
+python prepare_contrived_descriptors.py \
+    --coco_fpath "$KWCOCO_FPATH" \
+    --out_chips_dpath "$CHIPPED_IMAGES_DPATH" \
+    --out_mainfest_fpath "$MANIFEST_FPATH"
+
+
+echo "
+------
+Step 3
+------
+Ingest the images and descriptors into the SMQTK database.
+"
+# NOTE: there is a "workdir" in the runApp configs, which will put outputs in
+# this working directory. TODO: make this specifiable on the CLI here.
+# 2. Generate the SMQTK-IQR data set, descriptor set and faiss nnindex
+python ingest_precomputed_descriptors.py \
+    --verbose=True \
+    --config runApp.IqrSearchApp.json runApp.IqrRestService.json \
+    --manifest_fpath "$MANIFEST_FPATH" \
+    --debug_nn_index=True \
+    --tab "GEOWATCH_DEMO"
+
+echo "
+Step 4
+------
+Ensure MongoDB is running
+"
+if ! systemctl status mongod --no-pager; then
+    sudo systemctl start mongod
+    systemctl status mongod --no-pager
+fi
+
+
+echo "
+Step 5
+------
+Run the IQR search dispatcher and IQR service from the same directory.
+
+Alternative: Instead of running the commands in tmux sessions, you can simply
+two open different terminals and execute the service and dispatcher in each
+
+In the first terminal:
+
+    runApplication -a IqrService -c runApp.IqrRestService.json
+
+In the second terminal:
+
+    runApplication -a IqrSearchDispatcher -c runApp.IqrSearchApp.json
+"
+
+# NOTE: ensure the relevant venv is activated in the new sessions.
+
+# Following script provides commands to run in a single tmux session
+# with two split windows
+SESSION_NAME="SMQTK-TUTORAL1-SERVERS"
+tmux kill-session -t "${SESSION_NAME}" || true
+tmux new-session -d -s "${SESSION_NAME}" "/bin/bash"
+tmux rename-window -t "${SESSION_NAME}:0" 'main'
+
+COMMAND="runApplication -v -a IqrService -c runApp.IqrRestService.json"
+tmux split-window -v -t "${SESSION_NAME}:0.0"
+tmux select-pane -t "${SESSION_NAME}:0.0"
+tmux send -t "$SESSION_NAME" "$COMMAND" Enter
+
+COMMAND="runApplication -v -a IqrSearchDispatcher -c runApp.IqrSearchApp.json"
+tmux select-pane -t "${SESSION_NAME}:0.1"
+tmux send -t "$SESSION_NAME" "$COMMAND" Enter
+
+# Fixup the pane layout
+tmux select-layout -t "${SESSION_NAME}" even-vertical
+
+# 6. Open a web-browser and navigate to 'localhost:5000'
+python -c "import webbrowser; webbrowser.open('127.0.0.1:5000')"
+
+# Reminder: ctrl+b + <arrow-key> lets you move between splits
+# within a tmux session.
+if [[ "$TMUX" == "" ]]; then
+    # not in tmux, attach to the session
+    tmux attach-session -t "${SESSION_NAME}"
+else
+    # already in tmux, switch to the session
+    tmux switch -t "${SESSION_NAME}"
+fi
+
+echo "
+THE FOLLOWING ARE MANUAL STEPS THE USER MUST TAKE.
+
+7. In the web-browser, select 'GEOWATCH_DEMO' IQR instance
+
+8. Both username and password are set to 'demo' by config files
+
+9. You may now interact with the IQR web interface.
+"

--- a/smqtk_iqr/utils/runApplication.py
+++ b/smqtk_iqr/utils/runApplication.py
@@ -11,6 +11,7 @@ from flask_cors import CORS
 
 from smqtk_iqr.utils import cli
 import smqtk_iqr.web
+import sys
 
 
 def cli_parser() -> ArgumentParser:
@@ -123,16 +124,16 @@ def main() -> None:
                          cast(str, cls.__doc__) + '\n' +
                          ('*' * 80) + '\n')
         log.info("")
-        exit(0)
+        sys.exit(0)
 
     application_name = args.application
 
     if application_name is None:
         log.error("No application name given!")
-        exit(1)
+        sys.exit(1)
     elif application_name not in web_applications:
         log.error("Invalid application label '%s'", application_name)
-        exit(1)
+        sys.exit(1)
 
     app_class: Type[smqtk_iqr.web.SmqtkWebApp] = web_applications[application_name]
 


### PR DESCRIPTION
This builds on top of 

* https://github.com/Kitware/SMQTK-IQR/pull/37
* https://github.com/Kitware/SMQTK-IQR/pull/38
* https://github.com/Kitware/SMQTK-IQR/pull/39

This will need to be rebased once the above are merged, and the diff should be much cleaner. 

The main parts of this PR is just the first very basic tutorial. 

* Add quick documentation about setting up mongodb
* Adds a single new tutorial based on automatically generate descriptors

There are two more tutorials that use increasingly realistic descriptors, but also take more time and in some cases have external requirements. Thus I'd like to separate out the simple one for review first.  